### PR TITLE
Bower updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,13 @@
 {
   "name": "jquery.group.js",
   "description" : "A jQuery extension for wrapping sets of elements at one time",
-  "version": "1.3",
-  "main": ["jquery.group.min.js"],
+  "version": "1.3.0",
+  "main": ["jquery.group.js"],
   "dependencies": {
     "jquery": ">=1.4"
   },
   "ignore": [
     "**/.*",
-    "test",
-    "jquery.group.js"
+    "test"
   ]
 }


### PR DESCRIPTION
Three changes.
1. Updated the version number to be a [semantic version number](http://semver.org/) (three digits).
2. Designated the 'main' file as the expanded version after this [discussion](https://github.com/bower/bower/issues/393)
3. Removed `jquery.group.js` from the list of ignored files.
